### PR TITLE
BREAKING - Remove /_meta/projects/{project name}/{project name}-{error message}.json

### DIFF
--- a/src/handlers/errors/get.js
+++ b/src/handlers/errors/get.js
@@ -90,15 +90,6 @@ module.exports.get = (event, context, cb) => {
         MaxKeys: 1
     };
 
-    // deprecated
-    // Get _meta/projects/{project name}/{error message}/{project name}-{error message}.json
-    const metaFilename = [project, message].join('-').replace('/','-') + '.json';
-    const metaBucketKey = ['_meta', 'projects', project, message, metaFilename].join('/');
-    const metaBucketParams = {
-        Bucket: bucketName,
-        Key: metaBucketKey
-    };
-
     const docParams = {
         TableName: errorByTimeunitTable,
         KeyConditionExpression: '#key = :key AND #timestamp BETWEEN :from AND :to',
@@ -117,6 +108,13 @@ module.exports.get = (event, context, cb) => {
         .then((data) => {
             if (data.Contents.length == 0) {
                 // deprecated
+                // Get _meta/projects/{project name}/{error message}/{project name}-{error message}.json
+                const metaFilename = [project, message].join('-').replace('/','-') + '.json';
+                const metaBucketKey = ['_meta', 'projects', project, message, metaFilename].join('/');
+                const metaBucketParams = {
+                    Bucket: bucketName,
+                    Key: metaBucketKey
+                };
                 return Promise.all([
                     storage.getObject(metaBucketParams),
                     storage.queryDoc(docParams),

--- a/src/handlers/errors/get.js
+++ b/src/handlers/errors/get.js
@@ -82,6 +82,15 @@ module.exports.get = (event, context, cb) => {
 
     const key = [project, message].join('##');
 
+    const occurrencePrefix = ['projects', project, 'errors', message, 'occurrences'].join('/') + '/';
+    const occurrencesDirParams = {
+        Bucket: bucketName,
+        Delimiter: '/',
+        Prefix: occurrencePrefix,
+        MaxKeys: 1
+    };
+
+    // deprecated
     // Get _meta/projects/{project name}/{error message}/{project name}-{error message}.json
     const metaFilename = [project, message].join('-').replace('/','-') + '.json';
     const metaBucketKey = ['_meta', 'projects', project, message, metaFilename].join('/');
@@ -104,10 +113,21 @@ module.exports.get = (event, context, cb) => {
         }
     };
 
-    Promise.resolve()
-        .then(() => {
+    storage.listObjects(occurrencesDirParams)
+        .then((data) => {
+            if (data.Contents.length == 0) {
+                // deprecated
+                return Promise.all([
+                    storage.getObject(metaBucketParams),
+                    storage.queryDoc(docParams),
+                ]);
+            }
+            const occurrenceParams = {
+                Bucket: bucketName,
+                Key: data.Contents[0].Key
+            };
             return Promise.all([
-                storage.getObject(metaBucketParams),
+                storage.getObject(occurrenceParams),
                 storage.queryDoc(docParams),
             ]);
         })

--- a/src/handlers/errors/post.js
+++ b/src/handlers/errors/post.js
@@ -123,16 +123,6 @@ module.exports.post = (event, context, cb) => {
             ContentType: 'application/json'
         };
 
-        // Put _meta/projects/{project name}/{error message}/{project name}-{error message}.json
-        const metaFilename = [project, message].join('-').replace('/','-') + '.json';
-        const metaBucketKey = ['_meta', 'projects', project, message, metaFilename].join('/');
-        const metaBucketParams = {
-            Bucket: bucketName,
-            Key: metaBucketKey,
-            Body: JSON.stringify(errorData, null, 2),
-            ContentType: 'application/json'
-        };
-
         const docByTimeunitParams = {
             TableName: errorByTimeunitTable,
             Key: {
@@ -178,13 +168,7 @@ module.exports.post = (event, context, cb) => {
         };
 
         promises.push(
-            Promise.resolve()
-                .then(() => {
-                    return Promise.all([
-                        storage.putObject(occurrenceBucketParams),
-                        storage.putObject(metaBucketParams),
-                    ]);
-                })
+            storage.putObject(occurrenceBucketParams)
                 .then(() => {
                     return Promise.all([
                         storage.updateDoc(docByTimeunitParams),


### PR DESCRIPTION
Get error meta data from

before

```
/_meta/projects/{project name}/{project name}-{error message}.json
```

after

```
/projects/{project name}/errors/{project name}/errors/{error message}/occurrences/[first].json
```

So `/_meta/` is deprecated.