### PR TITLE
Add `linkTemplate` option for notifications config

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "lodash": "^4.16.2",
     "moment": "^2.15.0",
     "moment-timezone": "^0.5.13",
-    "serverless": "~1.13.1"
+    "serverless": "~1.13.1",
+    "url-template": "^2.0.8"
   },
   "devDependencies": {
     "aws-sdk": "^2.7.7"

--- a/schema.json
+++ b/schema.json
@@ -469,6 +469,7 @@
         "iconEmoji": {"type": "string"},
         "iconUrl": {"type": "string"},
         "timezone": {"type": "string"},
+        "linkTemplate": {"type": "string"},
         "icon_emoji": {"type": "string", "description": "deprecated"},
         "icon_url": {"type": "string", "description": "deprecated"}
       },
@@ -499,7 +500,8 @@
         "if_exist": {
           "enum": ["reopen", "comment", "reopen-and-comment", "reopen-and-update", "none"]
         },
-        "timezone": {"type": "string"}
+        "timezone": {"type": "string"},
+        "linkTemplate": {"type": "string"}
       },
       "required": ["type", "userToken", "owner", "repo"]
     },

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -2,6 +2,8 @@
 
 const github = require('github');
 const moment = require('moment-timezone');
+const template = require('url-template');
+const reversedUnixtime = require('./reversed_unixtime');
 
 module.exports = (n, errorData) => {
     const title = `[${errorData.type}] ${errorData.message}`;
@@ -25,6 +27,16 @@ module.exports = (n, errorData) => {
 
     function buildBody() {
         let body = '';
+
+        if (n.linkTemplate) {
+            const linkTemplate = template.parse(n.linkTemplate);
+            const link = linkTemplate.expand({
+                project: errorData.project,
+                message: errorData.message,
+                reversedUnixtime: reversedUnixtime(moment(errorData.timestamp, moment.ISO_8601).unix())
+            });
+            body += '## link\n\n\n' + link + '\n\n';
+        }
 
         if (errorData.backtrace) {
             let backtrace = '## backtrace\n\n';


### PR DESCRIPTION
If you set `linkTemplate` to notifications config, faultline expand link

from

`https://faultline.webui.example.com/index.html#/projects/{project}/errors/{message}/occurrences/{reversedUnixtime}`

to

`https://faultline.webui.example.com/index.html#/projects/sample-project/errors/Undefined%20index%20faultline/occurrences/9007197759633611`

## expandable params

- `{project}` : project name
- `{message}` : error message
- `{reverserdUnixtime}` : occurrence id