### PR TITLE
make bucket empty before remove

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "mocha": "^3.4.2",
     "nyc": "^11.0.2",
     "octopublish": "^0.5.0",
-    "power-assert": "^1.4.3"
+    "power-assert": "^1.4.3",
+    "serverless-s3-remover": "^0.2.0"
   }
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,6 +1,13 @@
 service: faultline
+
+plugins:
+  - serverless-s3-remover
+
 custom:
   config: ${file(./config.yml)}
+  remover:
+    buckets:
+      - ${self:custom.config.s3BucketName}
 
 frameworkVersion: ">=1.17.0 <2.0.0"
 


### PR DESCRIPTION
下記ブログ記事末尾に、```npm run destroy```の際にS3 Bucketを先に削除しないとdestroyに失敗するという記述があります
これはBucketが空ではないが故に起きる現象で、これと同じ現象に対応するために私はserverless-s3-removerを作成しました
faultlineのREADMEにあるdestroyの方法で失敗しないように、serverless-s3-removerの記述を追加してみました。
(自分の環境で、destroyが成功するのは確認してます)

[Serverless未経験おじさんのfaultline導入記 « LANCARD.LAB｜ランカードコムのスタッフブログ](http://www.lancard.com/blog/2017/08/02/serverless%E6%9C%AA%E7%B5%8C%E9%A8%93%E3%81%8A%E3%81%98%E3%81%95%E3%82%93%E3%81%AEfaultline%E5%B0%8E%E5%85%A5%E8%A8%98/)