### PR TITLE
Support multiple clientApiKeys

### DIFF
--- a/src/lib/middlewares/__tests__/checkApiKey.js
+++ b/src/lib/middlewares/__tests__/checkApiKey.js
@@ -58,4 +58,12 @@ describe('checkApiKey', () => {
         delete process.env.FAULTLINE_MASTER_API_KEY;
         assert(checkApiKey({ allowClientKey: true }).checkApiKey(event) === false);
     });
+
+    it ('if process.env.FAULTLINE_CLIENT_API_KEY contains a comma, checkApiKey assumes it is multiple keys and checks', () => {
+        process.env.FAULTLINE_CLIENT_API_KEY = 'CLIENT_API_KEY, OTHER_CLIENT_API_KEY';
+        event['headers']['X-Api-Key'] = 'CLIENT_API_KEY';
+        assert(checkApiKey({ allowClientKey: true }).checkApiKey(event) === true);
+        event['headers']['X-Api-Key'] = 'OTHER_CLIENT_API_KEY';
+        assert(checkApiKey({ allowClientKey: true }).checkApiKey(event) === true);
+    });
 });

--- a/src/lib/middlewares/checkApiKey.js
+++ b/src/lib/middlewares/checkApiKey.js
@@ -19,7 +19,11 @@ const middleware = (config = { allowClientKey: false }) => {
             }
             let checkKeys = [process.env.FAULTLINE_MASTER_API_KEY];
             if (config.allowClientKey) {
-                checkKeys.push(process.env.FAULTLINE_CLIENT_API_KEY);
+                if (process.env.FAULTLINE_CLIENT_API_KEY) {
+                    process.env.FAULTLINE_CLIENT_API_KEY.split(',').forEach((key) => {
+                        checkKeys.push(key.trim());
+                    });
+                }
             }
             if (checkKeys.indexOf(event.headers[apiKeyHeader]) < 0) {
                 return false;


### PR DESCRIPTION
<!--
If you ok, please write in english.
-->

Support multiple clientApiKeys ( `XXXXXXXXXXXXX` and `YYYYYYYYYYYYYYY` )

```yaml
clientApiKey: 'XXXXXXXXXXXXX, YYYYYYYYYYYYYYY'
```
